### PR TITLE
Disable Nav Performance Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ UK VFPC (UK VATSIM Flight Plan Checker) is a plugin for EuroScope that checks fi
 - `VFPC` tag item: Shows check-result and allows output of detailed checking data.
 - Tag function `Show Checks`: Outputs detailed checking data.
 - Checks validity of the filed initial route (to the extent specified by API - can be varied on a per-facility basis by local management).
+- ~~Checks that the aircraft has declared sufficient navigation capabilities for the requested route.~~ **Disabled until further notice.**
 - Checks that the aircraft type is valid for the filed SID.
 - Checks that the filed initial route is valid to the given destination.
 - Checks that the filed altitude follows any odd/even restrictions.
@@ -26,7 +27,7 @@ UK VFPC (UK VATSIM Flight Plan Checker) is a plugin for EuroScope that checks fi
 - `ENG` - Engine type is invalid for this SID/route.
 - `DST` - Filed destination is invalid for this SID.
 - `RTE` - Filed route is invalid for some reason.
-- `NAV` - Navigation performance is invalid for this SID/route.
+- ~~`NAV` - Navigation performance is invalid for this SID/route.~~ **Disabled until further notice.**
 - Alternating `MIN` and `MAX` - Filed altitude is outside of the allocated altitude block for this route.
 - `DIR` - Filed altitude is in violation of the Odd/Even altitude requirement for this route.
 - `SUF` - Assigned SID suffix is banned for this route.

--- a/analyzeFP.cpp
+++ b/analyzeFP.cpp
@@ -645,7 +645,7 @@ vector<vector<string>> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 					case 2:
 					{
 						//Nav Perf
-						if (conditions[i].HasMember("nav") && conditions[i]["nav"].IsString()) {
+						/* if (conditions[i].HasMember("nav") && conditions[i]["nav"].IsString()) {
 							string navigation_constraints(conditions[i]["nav"].GetString());
 							if (string::npos == navigation_constraints.find_first_of(flightPlan.GetFlightPlanData().GetCapibilities())) {
 								new_validity.push_back(false);
@@ -656,7 +656,9 @@ vector<vector<string>> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 						}
 						else {
 							new_validity.push_back(true);
-						}
+						} */
+
+						new_validity.push_back(true); //Check disabled until future release
 						break;
 					}
 					case 3:


### PR DESCRIPTION
Updates #17 

Disabled to prevent erroneous results. To be revamped at a later date.