### PR TITLE
docs: add baseline CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @flyingscotsman59


### PR DESCRIPTION
## Summary
- add a baseline CODEOWNERS file
- default repository ownership to @flyingscotsman59